### PR TITLE
Support hex colors from config and placeholders

### DIFF
--- a/src/main/java/be/kakumi/kachat/listeners/SendMessageListener.java
+++ b/src/main/java/be/kakumi/kachat/listeners/SendMessageListener.java
@@ -42,6 +42,8 @@ public class SendMessageListener implements Listener {
             for(Placeholder placeholder : KAChatAPI.getInstance().getPlaceholders()) {
                 messageFormat = placeholder.format(player, channel, messageFormat);
             }
+            //Process all color codes from the original message and the placeholders
+            messageFormat = KAChatAPI.getInstance().processColors(messageFormat);
 
             List<Player> receivers = KAChatAPI.getInstance().getChatManager().getValidReceivers(channel, player);
 

--- a/src/main/java/be/kakumi/kachat/middlewares/message/ColorFormatter.java
+++ b/src/main/java/be/kakumi/kachat/middlewares/message/ColorFormatter.java
@@ -5,9 +5,7 @@ import org.bukkit.entity.Player;
 
 public class ColorFormatter implements Formatter {
     public String format(Player player, String message) {
-        if (player.hasPermission("kachat.bypass.color")) {
-            message = message.replace("&", "§");
-        } else {
+        if (!player.hasPermission("kachat.bypass.color")) {
             message = message.replaceAll("§.", "");
             message = message.replaceAll("&.", "");
         }

--- a/src/main/java/be/kakumi/kachat/utils/ColorProcessor.java
+++ b/src/main/java/be/kakumi/kachat/utils/ColorProcessor.java
@@ -1,0 +1,29 @@
+package be.kakumi.kachat.utils;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public class ColorProcessor {
+    /**
+     * Parses hex colors into supported minecraft colors
+     * @param str The color code. The string must start with &# and follow with 6 hex digits describing the color.
+     * @return The same color formatted as supported by minecraft game engine.
+     */
+    public String parseHexFormat(String str) {
+        String[] parts = str.split("&#");
+
+        if (parts.length != 2) {
+            return str;
+        }
+
+        String color = parts[1]; //Get just the 6 hex digits describing the color
+        StringBuilder formatted = new StringBuilder("§x"); //&# is always replaced by §x
+        formatted.append(
+            //Split all 6 values and join them back placing § between them plus one extra at the beginning
+            Arrays.stream(color.split(""))
+                .collect(Collectors.joining("§", "§", ""))
+        );
+
+        return formatted.toString();
+    }
+}


### PR DESCRIPTION
Colors matching the format &# with 6 hex digits will now be processed into the minecraft color format.

Any combination of simple colors (both starting with & and § symbols) and hex colors (starting with &#) will be valid in any color field of the config, the formats, the user message (if they have permission) and strings coming from placeholders.