### PR TITLE
Add todo list, fix bugs, add events and add override words

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@ This plugin is a chat manager for minecraft. Avaible from spigot 1.7.10 to 1.16.
 <br>You can create a channel and configure them quite easily to be able to create a lot of chats with permission, world restriction and range. Also, this plugin provides some security checker and formatter like [PlaceholderAPI](https://www.spigotmc.org/resources/placeholderapi.6245/).
 <br>You can use our API to create custom channels and be able to create your behaviour for every chat. You can almost change everything, and it was the goal of this plugin.
 <br>**Actually, this plugin is in version 1.0 so feel free to suggest some ideas and report bugs.**
+
+## TODO
+- Add player's choice to see channels
+- Create channel by GUI
+- Support CustomModelData
+- Refactoring
+
 ## Commands
 - **/kareload**: Reload the config file
 - **/channel [channel] [player] [-fp (force permission)] [-fw (force world)] [-f (force all)]**: Change the channel of someone, or you by default

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>be.kakumi.kachat</groupId>
     <artifactId>KAChat</artifactId>
-    <version>1.5.1-SNAPSHOT</version>
+    <version>1.6-SNAPSHOT</version>
 
     <repositories>
         <repository>

--- a/src/main/java/be/kakumi/kachat/KAChat.java
+++ b/src/main/java/be/kakumi/kachat/KAChat.java
@@ -162,6 +162,9 @@ public class KAChat extends JavaPlugin {
                 } else {
                     channel.setFormat(defaultFormat);
                 }
+                if (getConfig().contains("chat.channels." + name + ".overrideWords")) {
+                    channel.setOverrideWords(getConfig().getStringList("chat.channels." + name + ".overrideWords"));
+                }
                 if (getConfig().contains("chat.channels." + name + ".custom")) {
                     for(String key : getConfig().getConfigurationSection("chat.channels." + name + ".custom").getKeys(false)) {
                         channel.getCustom().put(key, getConfig().get("chat.channels." + name + ".custom." + key));

--- a/src/main/java/be/kakumi/kachat/api/KAChatAPI.java
+++ b/src/main/java/be/kakumi/kachat/api/KAChatAPI.java
@@ -141,6 +141,7 @@ public class KAChatAPI implements Placeholder {
         	String symbol = channel.getOverrideSymbol();
 
             if (StringUtils.isNotEmpty(symbol) && message.startsWith(symbol)) return channel;
+            if (channel.getOverrideWords().size() > 0 && channel.containsOverrideWords(message)) return channel;
         }
 
         return null;

--- a/src/main/java/be/kakumi/kachat/api/VaultAPI.java
+++ b/src/main/java/be/kakumi/kachat/api/VaultAPI.java
@@ -54,7 +54,7 @@ public class VaultAPI implements Placeholder {
 
     public String format(Player player, Channel channel, String message) {
         //Economy
-        if (economyLoaded) {
+        if (economyLoaded && economy.isEnabled()) {
             message = message.replace("{vault_eco_name}", economy.getName());
             message = message.replace("{vault_eco_money}", economy.getBalance(player) + "");
             message = message.replace("{vault_eco_money.2f}", String.format("%.1f", economy.getBalance(player)));
@@ -63,7 +63,7 @@ public class VaultAPI implements Placeholder {
         }
 
         //Chat
-        if (chatLoaded) {
+        if (chatLoaded && chat.isEnabled()) {
             message = message.replace("{vault_chat_name}", chat.getName());
             message = message.replace("{vault_chat_player_prefix}", chat.getPlayerPrefix(player));
             message = message.replace("{vault_chat_player_suffix}", chat.getPlayerSuffix(player));
@@ -71,7 +71,7 @@ public class VaultAPI implements Placeholder {
         }
 
         //Permission
-        if (permissionLoaded) {
+        if (permissionLoaded && permission.isEnabled() && permission.hasSuperPermsCompat() && permission.hasGroupSupport()) {
             message = message.replace("{vault_perm_group}", permission.getPrimaryGroup(player));
         }
 

--- a/src/main/java/be/kakumi/kachat/enums/MessageNotSendReason.java
+++ b/src/main/java/be/kakumi/kachat/enums/MessageNotSendReason.java
@@ -1,0 +1,6 @@
+package be.kakumi.kachat.enums;
+
+public enum MessageNotSendReason {
+    PLUGIN,
+    SECURITY
+}

--- a/src/main/java/be/kakumi/kachat/events/ChannelPreSendEvent.java
+++ b/src/main/java/be/kakumi/kachat/events/ChannelPreSendEvent.java
@@ -2,22 +2,28 @@ package be.kakumi.kachat.events;
 
 import be.kakumi.kachat.models.Channel;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
-public class ChannelReceiveMessageEvent extends Event {
+public class ChannelPreSendEvent extends Event implements Cancellable {
     private final static HandlerList HANDLERS = new HandlerList();
+
+    private boolean cancelled;
+
     private final Channel channel;
     private final Player sender;
     private final List<Player> receivers;
     private final String messageFormat;
     private final String message;
 
-    public ChannelReceiveMessageEvent(Channel channel, Player sender, List<Player> receivers, String messageFormat, String message) {
+    public ChannelPreSendEvent(Channel channel, Player sender, List<Player> receivers, String messageFormat, String message) {
         super(true);
+        this.cancelled = false;
+
         this.channel = channel;
         this.sender = sender;
         this.receivers = receivers;
@@ -25,13 +31,19 @@ public class ChannelReceiveMessageEvent extends Event {
         this.message = message;
     }
 
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean b) {
+        this.cancelled = b;
+    }
+
     @NotNull
     @Override
     public HandlerList getHandlers() {
-        return HANDLERS;
-    }
-
-    public static HandlerList getHandlerList() {
         return HANDLERS;
     }
 

--- a/src/main/java/be/kakumi/kachat/events/MessageNotSendEvent.java
+++ b/src/main/java/be/kakumi/kachat/events/MessageNotSendEvent.java
@@ -1,0 +1,40 @@
+package be.kakumi.kachat.events;
+
+import be.kakumi.kachat.enums.MessageNotSendReason;
+import be.kakumi.kachat.models.Channel;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class MessageNotSendEvent extends Event {
+    private final static HandlerList HANDLERS = new HandlerList();
+    private Player player;
+    private Channel channel;
+    private MessageNotSendReason reason;
+
+    public MessageNotSendEvent(@NotNull Player who, Channel channel, MessageNotSendReason reason) {
+        super(true);
+        this.player = who;
+        this.channel = channel;
+        this.reason = reason;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public Channel getChannel() {
+        return channel;
+    }
+
+    public MessageNotSendReason getReason() {
+        return reason;
+    }
+}

--- a/src/main/java/be/kakumi/kachat/listeners/SendMessageListener.java
+++ b/src/main/java/be/kakumi/kachat/listeners/SendMessageListener.java
@@ -33,7 +33,7 @@ public class SendMessageListener implements Listener {
         KAChatAPI.getInstance().updateLastMessage(event.getSender(), event.getMessage());
 
         if (KAChatAPI.getInstance().getChatSaver() != null) {
-            KAChatAPI.getInstance().getChatSaver().addMessage(event.getMessageFormat(), event.isPosted());
+            KAChatAPI.getInstance().getChatSaver().addMessage(event.getMessageFormat());
         }
     }
 }

--- a/src/main/java/be/kakumi/kachat/middlewares/message/OverrideSymbolFormatter.java
+++ b/src/main/java/be/kakumi/kachat/middlewares/message/OverrideSymbolFormatter.java
@@ -9,7 +9,7 @@ public class OverrideSymbolFormatter implements Formatter {
     public String format(Player player, String message) {
         Channel channel = KAChatAPI.getInstance().getChannelFromMessage(message);
 
-        if (channel != null) {
+        if (channel != null && message.startsWith(channel.getOverrideSymbol())) {
             message = message.substring(channel.getOverrideSymbol().length());
         }
 

--- a/src/main/java/be/kakumi/kachat/middlewares/security/ChatProtect.java
+++ b/src/main/java/be/kakumi/kachat/middlewares/security/ChatProtect.java
@@ -10,7 +10,7 @@ import java.util.regex.Pattern;
 
 public class ChatProtect implements Checker {
     public boolean valid(Player player, Channel channel, String message) throws CheckerException {
-        if (Pattern.matches("^[\\w|\\d]{10,}$", message)) {
+        if (Pattern.matches("^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d@$!%*#?&._-]{8,}$", message)) {
             throw new SecurityProtectException();
         }
 

--- a/src/main/java/be/kakumi/kachat/models/Channel.java
+++ b/src/main/java/be/kakumi/kachat/models/Channel.java
@@ -5,7 +5,10 @@ import be.kakumi.kachat.exceptions.UpdateChannelCommandException;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 
 @SuppressWarnings("rawtypes")
 public class Channel {
@@ -24,6 +27,7 @@ public class Channel {
     private String setAutoWorld;
     private boolean delete;
     private String overrideSymbol;
+    private List<String> overrideWords;
     private HashMap<String, Object> custom;
 
     public Channel(String prefix, String command, String format) {
@@ -41,6 +45,7 @@ public class Channel {
         this.setAutoWorld = "";
         this.delete = true;
         this.overrideSymbol = "";
+        this.overrideWords = new ArrayList<>();
         this.custom = new HashMap<>();
     }
 
@@ -329,6 +334,33 @@ public class Channel {
 	public void setOverrideSymbol(@NotNull String overrideSymbol) {
         this.overrideSymbol = overrideSymbol;
 	}
+
+    /**
+     * Get words of this channel, it will enforce the message to be sent to this channel if it contains any of these words.
+     * @return Words
+     */
+    public List<String> getOverrideWords() {
+        return overrideWords;
+    }
+
+    /**
+     * Set words of this channel, it will enforce the message to be sent to this channel if it contains any of these words.
+     * @return Words
+     */
+    public void setOverrideWords(List<String> overrideWords) {
+        this.overrideWords = overrideWords;
+    }
+
+    /**
+     * Check if the message contains any words used by the channel
+     * @param message
+     * @return true if it contains any words
+     */
+    public boolean containsOverrideWords(String message) {
+        return overrideWords
+                .stream()
+                .anyMatch(x -> Arrays.stream(message.split(" ")).anyMatch(x::equalsIgnoreCase));
+    }
 
     /**
      * Get custom data for this channel using HashMap as key;value

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -47,6 +47,7 @@ chat:
       permissionToUse: "" #Permission to use this channel (/channel)
       permissionToSee: "" #Permission to see message from this channel
       overrideSymbol: "" #If the message starts with this symbol, it will be sent to this channel regardless of which channel the player has joined
+      overrideWords: [] #If the message contains any of these words, it will be sent to this channel regardless of which channel the player has joined, not case-sensitive
       cooldown: 0 #Cooldown between each message for this channel
       custom:
         useAnonyme: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,8 +1,9 @@
 name: KAChat
-version: 1.5
+version: 1.6
 main: be.kakumi.kachat.KAChat
 author: Kakumi
 softdepend: [PlaceholderAPI, Vault]
+api-version: 1.13
 commands:
   kareload:
     usage: "§cCommand: §f/kareload§c."


### PR DESCRIPTION
Fix : "Your message is strange, you can't send it.", now it will throw this error if you send a message that looks like a password (numbers + letters)
Fix : Crash with Vault if no permission plugin with groups installed
Update (API) : Remove posted attribute from ChannelReceiveMessageEvent
Update (API) : Add bypass for the method sendMessage
Update (API) : Add ChannelPreSendEvent (cancellable)
Update (API) : Add MessageNotSendEvent
Added : Channels can be selected by default if the message contains a specific word